### PR TITLE
fix: 将 `OSError` 修改为 `ImportError`

### DIFF
--- a/win32material/__init__.py
+++ b/win32material/__init__.py
@@ -3,7 +3,7 @@
 from platform import platform
 
 if not platform().startswith("Windows-10") and not platform().startswith("Windows-11"):
-    raise OSError("To use this package, you need to use Windows 10 or above")
+    raise ImportError("To use this package, you need to use Windows 10 or above")
 
 from .win32material import (BORDERTYPE, MICAMODE, MICATHEME, ApplyAcrylic,
                             ApplyDarkMode, ApplyMica, SetBorderColor,


### PR DESCRIPTION
根据 AI 大模型给出的建议，当包的运行条件不满足，应该引发 `ImportError` 而不是 `OSError` ……

~~我就说怎么捕获 `ImportError` 没有用呢🤣~~